### PR TITLE
feat: Implement a new light theme for GitHub Pages site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ description: thesomewhatyou's Old School Computer Revival Project - Optimize Min
 theme: just-the-docs
 plugins:
   - jekyll-remote-theme
-color_scheme: custom_theme
+color_scheme: light_theme
 
 theme: jekyll-theme-minimal
 title: TOSCR-project

--- a/docs/_sass/color_schemes/light_theme.scss
+++ b/docs/_sass/color_schemes/light_theme.scss
@@ -1,0 +1,127 @@
+// Light Theme for Just the Docs
+
+// Base colors
+$white:    #fff !default;
+$grey-lt-000: #fafbfc !default; // Lightest grey for backgrounds
+$grey-lt-100: #f1f1f1 !default; // Slightly darker grey for accents/borders
+$grey-lt-200: #e1e4e8 !default; // For borders or subtle dividers
+$grey-dk-000: #666 !default;    // Dark grey for secondary text
+$grey-dk-100: #586069 !default; // Dark grey for primary text
+$grey-dk-200: #444 !default;    // Darker grey for headings
+$grey-dk-300: #24292e !default; // Darkest grey, almost black
+
+$blue-000: #f0f8ff !default; // Alice blue - very light, for subtle highlights
+$blue-100: #cfe8fc !default; // Light blue for info callouts or accents
+$blue-200: #007bff !default; // Primary blue for links and buttons
+$blue-300: #0056b3 !default; // Darker blue for hover states
+
+$green-100: #e6ffed !default; // Light green for success callouts
+$green-200: #28a745 !default; // Success green
+
+$yellow-100: #fff9e6 !default; // Light yellow for warning callouts
+$yellow-200: #ffc107 !default; // Warning yellow
+
+$red-100: #ffe6e6 !default;   // Light red for error callouts
+$red-200: #dc3545 !default;   // Error red
+
+// Theme colors
+$body-background-color: $white;
+$body-text-color: $grey-dk-100;
+$body-heading-color: $grey-dk-300;
+$link-color: $blue-200;
+$link-hover-color: $blue-300;
+$nav-child-link-color: $grey-dk-000;
+$nav-child-link-hover-color: $link-color;
+
+// Sidebar
+$sidebar-background-color: $grey-lt-000;
+$sidebar-border-color: $grey-lt-200; // Added for a subtle separation
+$nav-active-color: $link-color; // Active nav item matches link color
+
+// Code blocks
+$code-background-color: $grey-lt-100;
+$code-text-color: $grey-dk-200;
+$code-border-color: $grey-lt-200; // Added for consistency
+
+// Borders
+$border-color: $grey-lt-200;
+$table-border-color: $grey-lt-200;
+$hr-border-color: $grey-lt-200;
+
+// Callouts
+$feedback-background-color: $grey-lt-100; // Default callout background
+$feedback-text-color: $grey-dk-100;       // Default callout text
+
+$info-background-color: $blue-100;
+$info-text-color: $blue-300;
+
+$warning-background-color: $yellow-100;
+$warning-text-color: #c89600; // Darker yellow for text for contrast
+
+$danger-background-color: $red-100;
+$danger-text-color: $red-200;
+
+$success-background-color: $green-100;
+$success-text-color: $green-200;
+
+
+// Buttons
+$btn-primary-color: $white;
+$btn-primary-background-color: $blue-200;
+$btn-primary-hover-background-color: $blue-300;
+
+$btn-secondary-color: $blue-200;
+$btn-secondary-background-color: $white;
+$btn-secondary-hover-background-color: $grey-lt-100;
+
+
+// Responsive tables
+$table-background-color: $white;
+$table-header-color: $grey-dk-300;
+$table-row-stripe-color: $grey-lt-000;
+
+// Search
+$search-background-color: $white;
+$search-result-background-color: $grey-lt-000;
+$search-result-border-color: $border-color;
+$search-result-text-color: $body-text-color;
+$search-input-background-color: $grey-lt-100;
+$search-input-text-color: $body-text-color;
+$search-focussed-input-background-color: $white;
+$search-focussed-input-border-color: $blue-200; // Highlight search on focus
+
+// Footer
+$footer-background-color: $grey-lt-000;
+$footer-text-color: $grey-dk-000;
+$footer-link-color: $link-color;
+
+// Syntax highlighting variables (light theme)
+// These are typical names, Just the Docs might use its own specific ones if it has built-in themes
+// For a truly light syntax theme, you'd usually define many more specific token colors.
+// This is a basic set.
+$code-syntax-comment: #6a737d; // Grey for comments
+$code-syntax-keyword: #d73a49; // Reddish for keywords
+$code-syntax-string: #032f62;  // Dark blue for strings
+$code-syntax-number: #005cc5;  // Blue for numbers
+$code-syntax-variable: #e36209; // Orange for variables/constants
+$code-syntax-function: #6f42c1; // Purple for function names
+$code-syntax-tag: #22863a;      // Green for HTML tags
+$code-syntax-attribute: #6f42c1; // Purple for HTML attributes
+$code-syntax-error: #b31d28;    // Dark red for errors
+$code-syntax-class: #6f42c1;    // Purple for class names
+$code-syntax-operator: #d73a49; // Reddish for operators
+$code-syntax-punctuation: $grey-dk-100; // Default text color for punctuation
+
+// Ensure that these general variables are used by the theme's SASS for syntax highlighting.
+// If Just the Docs uses specific variable names like `$gh-syntax-*` or `$rouge-*`,
+// those would need to be targeted. For now, this provides a base.
+
+// This line imports the base Just the Docs styles.
+// It's important if you are *overriding* a built-in theme's variables.
+// If this is a *new* color scheme from scratch for the theme,
+// you might not need to import a base color scheme.
+// For now, let's assume this file will be self-contained for the color definitions.
+// @import "./default"; // Or the name of the default jtd theme if needed as a base.
+// For a truly custom scheme, we define everything.
+// If certain elements are not styled, it means the theme expects variables we haven't defined.
+// This will become apparent during testing/review.

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,178 +1,177 @@
-// Custom SCSS rules for a retro computing / Matrix vibe
+// Custom SCSS rules for a lighter, cleaner theme
 
 // --- Fonts ---
+// Use system fonts for better readability and a more standard feel.
+// The color scheme file ($body-text-color, $body-heading-color) will handle colors.
 body, p, li, td, th, input, textarea, button, .btn {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
-  font-size: 0.95rem; // Slightly adjust for monospace readability
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 1rem; // Standard font size
 }
 
 h1, h2, h3, h4, h5, h6, .site-title {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
-  text-shadow: 1px 1px 0px #003300, // Darker green shadow
-               2px 2px 0px #002200; // Even darker outline
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  // Remove retro text shadow
+  text-shadow: none;
 }
 
 .site-title {
-  font-size: 2.5rem; // Make title bigger
-  letter-spacing: 0.1em;
+  font-size: 2.2rem; // Slightly adjusted size
+  letter-spacing: normal; // Standard letter spacing
+  font-weight: 600; // A bit bolder for the title
 }
 
 // --- General Enhancements ---
 html {
-  // Subtle scanlines effect for the background
-  // background-image: linear-gradient(rgba(0, 255, 0, 0.03) 50%, transparent 50%);
-  // background-size: 100% 3px;
-  // For a more prominent effect, adjust opacity and size.
-  // This can be performance intensive or too distracting, so keeping it commented for now.
+  // Remove scanlines effect
 }
 
 // --- Warning/Callout Styling ---
-// `just-the-docs` uses callouts. Common classes are .callout .callout--warning
-// The ⚠️ emoji itself is just text, so it should pick up the $feedback-color from the scheme.
-
+// Rely primarily on the color scheme variables for callouts.
+// Add some subtle styling for a modern look.
 .callout {
-  border-left-width: 5px; // Make border more prominent
-  border-radius: 0px; // Sharp corners
+  border-left-width: 4px;
+  border-radius: 4px; // Slightly rounded corners
   padding: 1em 1.5em;
-  box-shadow: 3px 3px 5px rgba(0, 50, 0, 0.3); // Subtle green shadow
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05); // Softer shadow
+  margin-bottom: 1.5rem; // Add some space below callouts
 }
 
-.callout--warning {
-  // Use variables defined in `custom_theme.scss` if they are correctly picked up.
-  // If not, we can override directly here.
-  // background-color: $feedback-background-color; // Should be inherited
-  // border-left-color: $feedback-color;          // Should be inherited
+// Specific callout text colors are defined in light_theme.scss
+// Example: .callout--warning p, .callout--warning strong should use $warning-text-color
+// No need to override here if the theme variables are working as expected.
 
-  // Ensure the text inside the warning callout also uses the feedback color for emphasis
-  p, strong {
-    color: $feedback-color !important; // Bright yellow text
-  }
-
-  // Make the emoji icon itself more distinct if needed
-  &::before { // Some themes use ::before for icons in callouts
-    // color: $feedback-color; // Example if the icon color needs explicit setting
-  }
-}
-
-// Enhance blockquotes to match the theme
+// --- Blockquotes ---
 blockquote {
-  border-left: 4px solid $link-color; // Green border
-  padding-left: 1rem;
+  border-left: 3px solid $grey-lt-200; // Use a border color from the light theme
+  padding-left: 1.5rem;
   margin-left: 0;
-  color: #00CC00; // Slightly dimmer green for quote text
+  margin-bottom: 1.5rem;
+  color: $grey-dk-000; // Slightly lighter text for quotes, defined in light_theme
   font-style: italic;
-  background-color: #051005; // Very dark green, subtle background
-  border-radius: 0;
-  box-shadow: 2px 2px 3px rgba(0, 30, 0, 0.2);
+  background-color: $grey-lt-000; // Very light grey background
+  border-radius: 4px;
+  box-shadow: none; // Remove previous shadow
 }
 
 // --- Links ---
 a {
-  text-decoration: none; // Remove underline, rely on color
-  transition: color 0.2s ease-in-out, text-shadow 0.2s ease-in-out;
+  text-decoration: none; // Keep underline off by default, color is primary indicator
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, text-decoration 0.15s ease-in-out;
 }
 
 a:hover {
-  text-decoration: none;
-  text-shadow: 0 0 5px $link-hover-color, 0 0 10px $link-hover-color; // Glowing effect
+  text-decoration: underline; // Add underline on hover for clarity
+  color: $link-hover-color; // Ensure hover color from theme is used
+  // Remove glowing text shadow
+  text-shadow: none;
 }
 
 // --- Code Blocks ---
-// The color scheme variables should handle most of this.
-// Additional tweaks if needed:
+// Rely on color scheme variables. Add some general styling.
 pre, code {
-  border-radius: 0px; // Sharp corners for code blocks
-  border: 1px solid $border-color;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !important; // Ensure monospace
+  border-radius: 4px; // Rounded corners for code blocks
+  border: 1px solid $code-border-color; // Use variable from light_theme.scss
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace; // Keep monospace for code
 }
 
 pre {
-  padding: 0.8em;
-  box-shadow: 2px 2px 5px rgba(0, 30, 0, 0.3);
+  padding: 1em;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05); // Softer shadow for code blocks
+  background-color: $code-background-color; // Ensure this is applied
+}
+
+code {
+  background-color: $code-background-color; // For inline code
+  padding: 0.2em 0.4em;
+  font-size: 0.9em;
 }
 
 // --- Header/Navigation ---
 .site-header {
-  border-bottom: 2px solid $border-color !important; // Thicker, green border
-  box-shadow: 0 2px 5px rgba(0, 50, 0, 0.3);
+  border-bottom: 1px solid $border-color !important; // Thinner border, use theme variable
+  box-shadow: 0 1px 3px rgba(0,0,0,0.03); // Softer, more subtle shadow
 }
 
 // --- Buttons ---
 .btn {
-  border-radius: 0;
-  border: 1px solid $btn-primary-color;
-  text-shadow: 1px 1px 0px rgba(0,0,0,0.5);
-  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  border-radius: 4px; // Rounded buttons
+  border: 1px solid transparent; // Border color can be handled by background or specific btn types
+  text-shadow: none; // Remove text shadow
+  padding: 0.5em 1em;
+  font-weight: 500;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
 .btn:hover {
-  box-shadow: 0 0 8px $btn-primary-color;
+  // Hover effects defined by $btn-primary-hover-background-color etc. in the theme
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1); // Subtle shadow on hover
 }
 
 // --- Make selection match the theme ---
+// Using theme variables from light_theme.scss for selection
 ::selection {
-  background: $text-color; /* Green background */
-  color: $body-background-color; /* Dark text */
+  background: $blue-200; // Primary blue for selection background
+  color: $white;        // White text for selection
 }
 ::-moz-selection { /* Firefox */
-  background: $text-color;
-  color: $body-background-color;
+  background: $blue-200;
+  color: $white;
 }
 
 // --- Scrollbar (for Webkit browsers) ---
+// Standard scrollbar or a more subtle light theme scrollbar
 ::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
 }
 ::-webkit-scrollbar-track {
-  background: $sidebar-background-color;
-  border-left: 1px solid $border-color;
+  background: $grey-lt-100; // Light grey track
 }
 ::-webkit-scrollbar-thumb {
-  background: $link-color;
-  border: 1px solid $text-color;
+  background: $grey-lt-200; // Slightly darker grey thumb
+  border-radius: 4px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: $link-hover-color;
+  background: $grey-dk-000; // Darker on hover
 }
 ::-webkit-scrollbar-corner {
-  background: $sidebar-background-color;
+  background: $grey-lt-100;
 }
 
-// --- Add a subtle animation to the title ---
-.site-title a { // Target the link within the site-title for the animation
-  display: inline-block; // Necessary for transform
-  animation: flickerTitle 3s infinite alternate ease-in-out;
+// --- Remove animations ---
+// Remove flickerTitle animation
+.site-title a {
+  display: inline-block;
+  animation: none; // Remove animation
 }
 
-@keyframes flickerTitle {
-  0%, 18%, 22%, 25%, 53%, 57%, 100% {
-    text-shadow:
-      0 0 4px #00ff00,
-      0 0 11px #00ff00,
-      0 0 19px #00ff00,
-      0 0 40px #00aa00,
-      0 0 80px #00aa00,
-      0 0 90px #00aa00,
-      0 0 100px #00aa00,
-      0 0 150px #00aa00;
-    color: #ccffcc; // Slightly lighter text during glow
-  }
-  20%, 24%, 55% {
-    text-shadow: none;
-    color: $text-color;
-  }
-}
-
-// Add a blinking cursor effect after the main title
+// Remove blinking cursor effect
 .site-title a::after {
-  content: '_';
-  animation: blink-caret 1s step-end infinite;
-  margin-left: 0.2em;
-  font-weight: bold; // Make cursor more prominent
+  content: ''; // Remove content
+  animation: none; // Remove animation
+  margin-left: 0;
 }
 
-@keyframes blink-caret {
-  from, to { opacity: 0 }
-  50% { opacity: 1 }
+// General page width and main content adjustments for readability
+.main-content {
+  max-width: 800px; // Adjust for comfortable reading width if needed
+  margin: 0 auto;
+  padding: 2rem 1rem; // Add some padding
+}
+
+// Improve spacing for headings
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+h1 { font-size: 2rem; }
+h2 { font-size: 1.75rem; }
+h3 { font-size: 1.5rem; }
+// etc.
+
+// Responsive images
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px; // Optional: slightly rounded images
 }


### PR DESCRIPTION
This commit introduces a new light color scheme and revises custom styles to give the GitHub Pages site a brighter, more modern look and feel.

Key changes:
- Added `light_theme.scss` with a new color palette.
- Updated `_config.yml` to use `light_theme`.
- Modified `custom.scss` to:
    - Use system UI fonts for body text.
    - Remove retro/Matrix-themed styles (text shadows, animations).
    - Update styling for various elements (callouts, links, buttons, code blocks) to match the light theme with softer shadows and rounded corners.
    - Standardize scrollbar and text selection appearance.